### PR TITLE
Update time version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ libc = "0.2"
 getopts = "0.2"
 rustc-serialize = "0.3"
 term = "0.4"
-time = "0.1"
+time = "0.1.39"
 
 [build-dependencies]
 rustc_version = "0.2.1"


### PR DESCRIPTION
Old versions of `time` don't work with current Rust versions. Everything below 0.1.39 is highly problematic and breaks `-Z minimal-versions`. I suggest not allowing a version so old that you don't expect anyone to actually use it.
