### PR TITLE
Update to rust-time@0.3.11.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,4 @@
+# Modified by Maxime Devos (see 4(b) of the Apache license)
 [package]
 name = "rustc-test"
 version = "0.3.1"
@@ -15,7 +16,7 @@ libc = "0.2"
 getopts = "0.2"
 rustc-serialize = "0.3"
 term = "0.4"
-time = "0.1"
+time = "0.3"
 
 [build-dependencies]
 rustc_version = "0.2.1"


### PR DESCRIPTION
The benchmarks and tests fail to compile, though this seems unrelated to the time update.